### PR TITLE
Improvement/readme gitignore update

### DIFF
--- a/.ask/config
+++ b/.ask/config
@@ -1,9 +1,0 @@
-{
-  "deploy_settings": {
-    "default": {
-      "skill_id": "",
-      "was_cloned": false,
-      "merge": {}
-    }
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -221,7 +221,7 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk 
+# Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk
 
@@ -317,7 +317,7 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Azure Stream Analytics local run output 
+# Azure Stream Analytics local run output
 ASALocalRun/
 
 # MSBuild Binary and Structured Log
@@ -326,12 +326,13 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/
 
-#Added by jaime 
-*.jaime  
+#Added by jaime
+*.jaime
 =======
- 
+
 lambda/custom/package-lock.json
 lambda/custom/.DS_Store
+.ask/config

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ In a system with [ASK CLI](https://developer.amazon.com/en-US/docs/alexa/smapi/q
     ```
     ask deploy
     ```
-1. Go to the [Alexa developer portal](https://developer.amazon.com/alexa/console/ask), click on the skill, and then go into the test tab and invoke the skill.
+1. Go to the [Alexa developer portal](https://developer.amazon.com/alexa/console/ask), click on the skill, and then go into the test tab and invoke the skill. Alternatively, you can invoke the skill on any Alexa-enabled devices that are tied to the same Amazon user account as your developer account.
 
-1. Alternatively, you can invoke the skill on any Alexa-enabled devices that are tied to the same Amazon user account as your developer account.
+1. Having a local environment for debugging is super helpful. Follow this [Alexa Blog](https://developer.amazon.com/blogs/alexa/post/77c8f0b9-e9ee-48a9-813f-86cf7bf86747/setup-your-local-environment-for-debugging-an-alexa-skill) to setup your local debug workflow.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# APL snippets  
-This repo is a collection of snippets for developers building Alexa APL skills.   
+# APL snippets
+This repo is a collection of snippets for developers building Alexa APL skills.
 
 
 ## Goals:
@@ -7,73 +7,83 @@ Each snippet is a working APL document you can use to  understand an APL feature
 
 
 ## Non-goals:
-- This is not a comprehensive introduction to APL.  It is aimed at intermediate developers who are already familiar with the basics.   
-- If you are just started, try the [visual cakewalk](https://alexa.design/apl-cake-walk) course first. 
+- This is not a comprehensive introduction to APL.  It is aimed at intermediate developers who are already familiar with the basics.
+- If you are just started, try the [visual cakewalk](https://alexa.design/apl-cake-walk) course first.
 
-- The snippets are not clean (or polished) enough for copy/paste reuse.  
+- The snippets are not clean (or polished) enough for copy/paste reuse.
 
 ## Repo structure
-This is a working Alexa skill. You can clone it and run it (see instructions below).   
+This is a working Alexa skill. You can clone it and run it (see instructions below).
 
-Here is the hierarchy, so you can navigate through the code: 
+Here is the hierarchy, so you can navigate through the code:
 
-- &lt;root&gt;/lambda/custom/aplsamples/   
-Contains all the snippets.    
-Each feature has their own subfolder with an APL document and a readme file.    
-Most snippets are self-contained, you should be able to copy/paste the document contents to the APL editor. When the snippet requires a data source commands, the readme will call it out.   
+- &lt;root&gt;/lambda/custom/aplsamples/
+Contains all the snippets.
+Each feature has their own subfolder with an APL document and a readme file.
+Most snippets are self-contained, you should be able to copy/paste the document contents to the APL editor. When the snippet requires a data source commands, the readme will call it out.
 
-- &lt;root&gt;/lambda/custom/skill    
-Contains the files needed for the demo to load and display the snippets. It has the intent handlers for the voice interactions.   
+- &lt;root&gt;/lambda/custom/skill
+Contains the files needed for the demo to load and display the snippets. It has the intent handlers for the voice interactions.
 
-- &lt;root&gt;/model/en-US.json   
- Has the voice interaction model. Use it to extract the utterances supported by the skill.  
+- &lt;root&gt;/model/en-US.json
+ Has the voice interaction model. Use it to extract the utterances supported by the skill.
 
 ## Contents
 [Will be updated to links soon]
- 
-Components: 
-- Text 
+
+Components:
+- Text
 - Image
-- TouchWrapper 
-- Video 
-- Pager 
-- Sequence 
+- TouchWrapper
+- Video
+- Pager
+- Sequence
 
 
 Commands:
-- SpeakItem using speech 
-- SpeakItem using transformers 
-- SpeakList 
-- OpenUrl 
+- SpeakItem using speech
+- SpeakItem using transformers
+- SpeakList
+- OpenUrl
 
-Features: 
-- Profile 
-- Animation 
-- Databinding  
-- Cached Pager 
-- States 
-- Environment 
-- Transport controls 
+Features:
+- Profile
+- Animation
+- Databinding
+- Cached Pager
+- States
+- Environment
+- Transport controls
 
-Scenario demos 
-- Spinner 
+Scenario demos
+- Spinner
 - Tic-tac-toe
 
 
-## Deploying/testing the script 
-In a system with [ASK CLI](https://developer.amazon.com/en-US/docs/alexa/smapi/quick-start-alexa-skills-kit-command-line-interface.html) and [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) installed:  
+## Deploying/testing the script
+In a system with [ASK CLI](https://developer.amazon.com/en-US/docs/alexa/smapi/quick-start-alexa-skills-kit-command-line-interface.html) and [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) installed:
 
-1. Clone this repo.   
-   _git clone https://github.com/jaimerodriguez/aplsnippets_ 
-1. Change directory to the root of the project.    
-    _cd aplsnippets_ 
-1. Associate the project with your Alexa developer account and your AWS account.  
-    _ask init_ 
-1. Deploy the project.  
-    _ask deploy_ 
-1. Go to the [Alexa developer portal](https://developer.amazon.com/alexa/console/ask), click on the skill, and then go into the test tab and invoke the skill.   
+1. Clone this repo.
+    ```
+    git clone https://github.com/jaimerodriguez/aplsnippets
+    ```
+1. Change directory to the root of the project.
+    ```
+    cd aplsnippets
+    ```
+1. Associate the project with your Alexa developer account and your AWS account.
+    ```
+    ask init
+    ```
+1. Deploy the project.
+    ```
+    ask deploy
+    ```
+1. Go to the [Alexa developer portal](https://developer.amazon.com/alexa/console/ask), click on the skill, and then go into the test tab and invoke the skill.
+
+1. Alternatively, you can invoke the skill on any Alexa-enabled devices that are tied to the same Amazon user account as your developer account.
 
 
 
 ## Contributing to the sample (or the docs)
-If you want to contribute a new snippet, or you want to contribute to the (very incomplete) documentation, you are very welcome to do so. Please submit a pull request. 
+If you want to contribute a new snippet, or you want to contribute to the (very incomplete) documentation, you are very welcome to do so. Please submit a pull request.

--- a/lambda/custom/.vscode/launch.json
+++ b/lambda/custom/.vscode/launch.json
@@ -3,18 +3,28 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
-    "configurations": [                
+    "configurations": [
         {
             "type": "node",
             "request": "launch",
             "name": "ngrok",
-            "program": "${workspaceRoot}/local-debugger.js",
+            "program": "${workspaceFolder}/local-debugger.js",
             "args": [
                 "--portNumber", "3001",
-                "--skillEntryFile", "${workspaceRoot}/index.js",
+                "--skillEntryFile", "${workspaceFolder}/index.js",
                 "--lambdaHandler", "handler"
             ],
-            "env" : { "DEBUGLOG" : "verbose" } 
+            "env" : { "DEBUGLOG" : "verbose" }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Proxy",
+            "program": "${workspaceRoot}/node_modules/bespoken-tools/bin/bst-proxy.js",
+            "args": ["lambda", "index.js"],
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": "/usr/local/bin/node" ,
+            "env" : { "DEBUGLOG" : "verbose" }
         }
     ]
 }

--- a/lambda/custom/package.json
+++ b/lambda/custom/package.json
@@ -13,7 +13,7 @@
     "ask-sdk-model": "^1.15.1"
   },
   "devDependencies": {
-    "bespoken-tools": "^2.3.14",
+    "bespoken-tools": "^2.4.55",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.2"


### PR DESCRIPTION
- Update markdown to README so command examples are easier to read
- Remove all trailing whitespaces (automatic cleanup by code editor)
- add `.ask/config` to `gitignore` since we don't want to checkin user's deploy settings after the skill is deployed to aws lambda

Screenshot:
![image](https://user-images.githubusercontent.com/21047496/77203176-07bdff00-6aad-11ea-92fe-7ad83443950e.png)

